### PR TITLE
Fix word boundary matching for artist names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: main.py",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/main.py",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/src/validator.py
+++ b/src/validator.py
@@ -68,9 +68,12 @@ def flag_key_match(artist: str) -> str | None:
     keys = flagged_artists.keys()
 
     if ' ' in artist:
-        # We have a space in the artist's name, do a partial match
+        # We have a space in the artist's name, check for word boundaries
+        # This handles cases like "Igorrr vs. Camellia" or "Artist feat. Another"
         for key in keys:
-            if key.lower() in artist.lower():
+            # Use word boundary regex to avoid false positives
+            pattern = r'\b' + re.escape(key.lower()) + r'\b'
+            if re.search(pattern, artist.lower()):
                 return key
     else:
         # No space in the artist's name, look for an exact match

--- a/tests/validator_test.py
+++ b/tests/validator_test.py
@@ -111,14 +111,57 @@ def test_edge_uma_vs_morimori_partial():
     # Needs to be disallowed because Morimori Atsushi is a prohibited artist
     assert(validator.is_partial(beatmapset))
 
-def test_edge_artist_one_word_flase_flag():
+def test_edge_artist_one_word_false_flag():
     """If a disallowed artist appears in the same word as another legitimate artist,
     it should not be flagged. i.e. NOMA inside of NOMANOA should not be flagged.
     NOMA vs. NOMANOA should be flagged."""
     beatmapset = __no_dmca_graveyard_beatmap()
     beatmapset.artist = 'nomanoa'
 
-    # Needs to be disallowed because Morimori Atsushi is a prohibited artist
+    # Should be allowed because NOMA should not match within NOMANOA
+    assert(validator.is_allowed(beatmapset))
+
+def test_word_boundary_tsunomaki_watame():
+    """Test that 'NOMA' does not flag 'Tsunomaki Watame' (false positive fix)"""
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'Tsunomaki Watame'
+    
+    # Should be allowed - NOMA should not match within Tsunomaki
+    assert(validator.is_allowed(beatmapset))
+
+def test_word_boundary_noma_vs_someone():
+    """Test that 'NOMA vs. Someone' correctly flags for 'NOMA'"""
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'NOMA vs. Good Artist'
+    
+    # Should be disallowed because NOMA is a word boundary match
+    assert(validator.is_disallowed(beatmapset))
+
+def test_word_boundary_edge_cases():
+    """Test various word boundary edge cases"""
+    # Test 1: Artist name at the beginning
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'NOMA feat. Someone'
+    assert(validator.is_disallowed(beatmapset))
+    
+    # Test 2: Artist name at the end
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'Someone feat. NOMA'
+    assert(validator.is_disallowed(beatmapset))
+    
+    # Test 3: Artist name in parentheses
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'Track (NOMA Remix)'
+    assert(validator.is_disallowed(beatmapset))
+    
+    # Test 4: Artist name with punctuation
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'NOMA, Someone Else'
+    assert(validator.is_disallowed(beatmapset))
+    
+    # Test 5: Partial match should not flag when part of another word
+    beatmapset = __no_dmca_graveyard_beatmap()
+    beatmapset.artist = 'Binomaly'  # Contains "noma" but shouldn't flag
     assert(validator.is_allowed(beatmapset))
 
 def test_disallowed_space_in_name():


### PR DESCRIPTION
Fixes false positives where artist names like 'NOMA' were matching within other words like 'Tsunomaki'.

Now uses regex word boundaries when checking multi-word artist names. Added test coverage for edge cases including vs/feat collaborations and punctuation handling.