### PR TITLE
Add strict mode, CSV validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,27 @@ Add this app to your Discord server with [this link](https://discord.com/oauth2/
 
 ### Commands
 
-The `validate` command is used to validate a collection of beatmaps against osu!'s [content usage permissions](https://osu.ppy.sh/wiki/en/Rules/Content_usage_permissions) rules. You can pass in a list of beatmap links or beatmap IDs, separated by a space.
+Both commands return compliance results and will inform you if any beatmaps are non-compliant. If you think you have received a false positive (where a beatmap is not marked correctly), please report an issue and [Stage](https://osu.ppy.sh/users/8191845) will review it with input from the Tournament Committee if necessary.
 
-The command returns the result and will inform you if any beatmaps are non-compliant. If you think you have received a false positive (where a beatmap is not marked correctly), please report an issue and [Stage](https://osu.ppy.sh/users/8191845) will review it with input from the Tournament Committee if necessary.
+#### `/validate`
+
+Validates a collection of beatmaps against osu!'s [content usage permissions](https://osu.ppy.sh/wiki/en/Rules/Content_usage_permissions) rules. Pass in a list of beatmap links or beatmap IDs, separated by a space.
 
 ```
-/validate <beatmaps>
+/validate <beatmaps> [strict]
 ```
+
+#### `/validate-csv`
+
+Validates a CSV file of artist/title metadata against osu!'s content usage permissions. Upload a `.csv` file with `artist` and `title` columns (case-insensitive). Optional columns: `artist_unicode`, `title_unicode`.
+
+```
+/validate-csv <file> [strict]
+```
+
+#### Strict mode
+
+Both commands accept an optional `strict` parameter (disabled by default). Strict mode adds additional checks against [game soundtrack databases](https://github.com/hburn7/omc-api/tree/master/data/strict) maintained in [omc-api](https://github.com/hburn7/omc-api). This is useful for world cups or other situations where compliance beyond the standard content usage permissions list is required.
 
 ## Bug reports
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,20 @@ Validates a collection of beatmaps against osu!'s [content usage permissions](ht
 
 #### `/validate-csv`
 
-Validates a CSV file of artist/title metadata against osu!'s content usage permissions. Upload a `.csv` file with `artist` and `title` columns (case-insensitive). Optional columns: `artist_unicode`, `title_unicode`.
+Validates a CSV file of artist/title metadata against osu!'s content usage permissions.
 
 ```
 /validate-csv <file> [strict]
+```
+
+The CSV must include a header row with `artist` and `title` columns (case-insensitive). Optionally include `artist_unicode` and `title_unicode` columns. Rows missing an artist or title are skipped. Both UTF-8 and UTF-8 with BOM encodings are supported.
+
+Example:
+
+```csv
+artist,title,artist_unicode,title_unicode
+Camellia,GHOST,かめりあ,GHOST
+Frums,memoryfactory.lzh,Frums,memoryfactory.lzh
 ```
 
 #### Strict mode

--- a/src/api.py
+++ b/src/api.py
@@ -1,7 +1,9 @@
+import os
 from dataclasses import dataclass
 from typing import Optional
-import os
+
 import aiohttp
+
 
 @dataclass
 class ValidationResponse:
@@ -15,39 +17,83 @@ class ValidationResponse:
     cover: Optional[str] = None
     artist: Optional[str] = None
     title: Optional[str] = None
+    artist_unicode: Optional[str] = None
+    title_unicode: Optional[str] = None
     ownerId: Optional[int] = None
     ownerUsername: Optional[str] = None
     status: str = ""
+
+
+@dataclass
+class RawValidationResponse:
+    complianceStatus: str
+    complianceStatusString: str
+    artist: str
+    title: str
+    artist_unicode: str
+    title_unicode: str
+    complianceFailureReason: Optional[str] = None
+    complianceFailureReasonString: Optional[str] = None
+    notes: Optional[str] = None
+
 
 @dataclass
 class ApiResponse:
     results: list[ValidationResponse]
     failures: list[int]
 
+
 # API response:
 # - Types: https://github.com/hburn7/omc-api/blob/6ca27c3ac58f0ece8616eacf37ff4c1a7e7b7a32/src/lib/dataTypes.ts#L33
 # - Response: https://github.com/hburn7/omc-api/blob/master/index.ts#L57
-async def validate(beatmap_ids: list[int]) -> Optional[ApiResponse]:
+async def validate(
+    beatmap_ids: list[int], strict: bool = False
+) -> Optional[ApiResponse]:
     secret = os.getenv("API_SECRET")
     if not secret:
         return None
-    
+
     endpoint = f"{os.getenv('API_URL')}/validate"
+    if strict:
+        endpoint += "?strict=true"
 
     async with aiohttp.ClientSession() as session:
-        async with session.post(endpoint, json=beatmap_ids, headers={
-            'X-Api-Key': secret
-        }) as response:
+        async with session.post(
+            endpoint, json=beatmap_ids, headers={"X-Api-Key": secret}
+        ) as response:
             if response.status != 200:
                 data = await response.json()
-                print(f'Failed to validate beatmaps due to non-200 status code: {data}')
+                print(f"Failed to validate beatmaps due to non-200 status code: {data}")
                 return None
 
             data = await response.json()
-            all_results = [ValidationResponse(**result) for result in data.get('results', [])]
-            all_failures = data.get('failures', [])
+            all_results = [
+                ValidationResponse(**result) for result in data.get("results", [])
+            ]
+            all_failures = data.get("failures", [])
 
-            return ApiResponse(
-                results=all_results,
-                failures=all_failures
-            )
+            return ApiResponse(results=all_results, failures=all_failures)
+
+
+async def validate_metadata(
+    inputs: list[dict], strict: bool = False
+) -> Optional[list[RawValidationResponse]]:
+    secret = os.getenv("API_SECRET")
+    if not secret:
+        return None
+
+    endpoint = f"{os.getenv('API_URL')}/validate-metadata"
+    if strict:
+        endpoint += "?strict=true"
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            endpoint, json=inputs, headers={"X-Api-Key": secret}
+        ) as response:
+            if response.status != 200:
+                data = await response.json()
+                print(f"Failed to validate metadata due to non-200 status code: {data}")
+                return None
+
+            data = await response.json()
+            return [RawValidationResponse(**item) for item in data]

--- a/src/client.py
+++ b/src/client.py
@@ -1,20 +1,24 @@
+import csv
+import io
 import logging
 import logging.handlers
 import os
-from typing import Optional
 from dataclasses import dataclass
+from typing import Optional, Sequence, Union
 
 import discord
-from discord import app_commands, Embed
+from discord import Embed, app_commands
 from dotenv import load_dotenv
-from reactionmenu import ViewMenu, ViewButton
+from reactionmenu import ViewButton, ViewMenu
 
 import api
-from constants import *
+import constants
+
+AnyValidationResponse = Union[api.ValidationResponse, api.RawValidationResponse]
 
 load_dotenv()
 
-logger = logging.getLogger('client')
+logger = logging.getLogger("client")
 
 intents = discord.Intents.default()
 intents.messages = True
@@ -28,117 +32,177 @@ tree = app_commands.CommandTree(client)
 
 @dataclass
 class CategorizedResponses:
-    ok: list[api.ValidationResponse]
-    potential: list[api.ValidationResponse]
-    disallowed: list[api.ValidationResponse]
+    ok: list[AnyValidationResponse]
+    potential: list[AnyValidationResponse]
+    disallowed: list[AnyValidationResponse]
     failed_ids: list[int]
-    
+    is_raw: bool = False
+
     @property
     def dmca_count(self) -> int:
-        return sum(1 for r in self.disallowed 
-                   if r.complianceFailureReason == ComplianceFailureReason.DMCA)
-    
+        return sum(
+            1
+            for r in self.disallowed
+            if r.complianceFailureReason == constants.ComplianceFailureReason.DMCA
+        )
+
     @property
     def other_disallowed_count(self) -> int:
-        return sum(1 for r in self.disallowed 
-                   if r.complianceFailureReason != ComplianceFailureReason.DMCA)
-    
+        return sum(
+            1
+            for r in self.disallowed
+            if r.complianceFailureReason != constants.ComplianceFailureReason.DMCA
+        )
+
     @property
     def potential_count(self) -> int:
         return len(self.potential)
-    
+
+    @property
+    def ok_count(self) -> int:
+        return len(self.ok)
+
     @property
     def graveyard_count(self) -> int:
-        return sum(1 for r in self.ok 
-                   if r.status not in ["ranked", "loved", "approved"])
-    
+        if self.is_raw:
+            return 0
+        return sum(
+            1
+            for r in self.ok
+            if getattr(r, "status", "") not in ["ranked", "loved", "approved"]
+        )
+
     @property
     def ranked_count(self) -> int:
-        return sum(1 for r in self.ok 
-                   if r.status in ["ranked", "loved", "approved"])
-    
+        if self.is_raw:
+            return 0
+        return sum(
+            1
+            for r in self.ok
+            if getattr(r, "status", "") in ["ranked", "loved", "approved"]
+        )
+
     @property
     def failed_count(self) -> int:
         return len(self.failed_ids)
-    
-    def get_combined_list(self) -> list[api.ValidationResponse]:
+
+    def get_combined_list(self) -> list[AnyValidationResponse]:
         combined = []
-        
-        dmca = [r for r in self.disallowed 
-                if r.complianceFailureReason == ComplianceFailureReason.DMCA]
+
+        dmca = [
+            r
+            for r in self.disallowed
+            if r.complianceFailureReason == constants.ComplianceFailureReason.DMCA
+        ]
         combined.extend(dmca)
-        
-        other_disallowed = [r for r in self.disallowed 
-                           if r.complianceFailureReason != ComplianceFailureReason.DMCA]
+
+        other_disallowed = [
+            r
+            for r in self.disallowed
+            if r.complianceFailureReason != constants.ComplianceFailureReason.DMCA
+        ]
         combined.extend(other_disallowed)
-        
+
         combined.extend(self.potential)
         combined.extend(self.ok)
-        
+
         return combined
 
 
 class ResponseFormatter:
     @staticmethod
-    def format_line_item(response: api.ValidationResponse) -> str:
-        base_url = OSU_BEATMAPSET_URL.format(response.beatmapsetId)
+    def format_line_item(response: AnyValidationResponse) -> str:
         icon = ResponseFormatter._get_icon(response)
-        
-        line = f"{icon} [{response.artist} - {response.title}]({base_url})"
-        
-        if (response.complianceStatus == ComplianceStatus.DISALLOWED and
-            response.complianceFailureReasonString and 
-            response.complianceFailureReason == ComplianceFailureReason.DISALLOWED_ARTIST):
+        beatmapset_id = getattr(response, "beatmapsetId", None)
+
+        if beatmapset_id is not None:
+            base_url = constants.OSU_BEATMAPSET_URL.format(beatmapset_id)
+            line = f"{icon} [{response.artist} - {response.title}]({base_url})"
+        else:
+            line = f"{icon} {response.artist} - {response.title}"
+
+        if (
+            response.complianceStatus == constants.ComplianceStatus.DISALLOWED
+            and response.complianceFailureReasonString
+            and response.complianceFailureReason
+            == constants.ComplianceFailureReason.DISALLOWED_ARTIST
+        ):
             line += f" - {response.complianceFailureReasonString}"
-        
+
         if response.notes:
             line += f" - {response.notes}"
-        
+
         return line
-    
+
     @staticmethod
-    def _get_icon(response: api.ValidationResponse) -> str:
-        if response.complianceStatus == ComplianceStatus.DISALLOWED:
-            if response.complianceFailureReason == ComplianceFailureReason.DMCA:
-                return ICON_DMCA
-            return ICON_DISALLOWED
-        elif response.complianceStatus == ComplianceStatus.POTENTIALLY_DISALLOWED:
-            return ICON_WARNING
-        else:  
-            if response.status in ["ranked", "approved"]:
-                return ICON_RANKED
-            elif response.status == "loved":
-                return ICON_LOVED
-            return ICON_OK
-    
+    def _get_icon(response: AnyValidationResponse) -> str:
+        if response.complianceStatus == constants.ComplianceStatus.DISALLOWED:
+            if (
+                response.complianceFailureReason
+                == constants.ComplianceFailureReason.DMCA
+            ):
+                return constants.ICON_DMCA
+            return constants.ICON_DISALLOWED
+        elif (
+            response.complianceStatus
+            == constants.ComplianceStatus.POTENTIALLY_DISALLOWED
+        ):
+            return constants.ICON_WARNING
+        else:
+            status = getattr(response, "status", None)
+            if status in ["ranked", "approved"]:
+                return constants.ICON_RANKED
+            elif status == "loved":
+                return constants.ICON_LOVED
+            return constants.ICON_OK
+
     @staticmethod
-    def categorize_responses(responses: list[api.ValidationResponse], 
-                           failed_ids: Optional[list[int]] = None) -> CategorizedResponses:
+    def categorize_responses(
+        responses: Sequence[AnyValidationResponse],
+        failed_ids: Optional[list[int]] = None,
+        is_raw: bool = False,
+    ) -> CategorizedResponses:
         ok = []
         potential = []
         disallowed = []
-        
+
         for r in responses:
-            if r.complianceStatus == ComplianceStatus.OK:
+            if r.complianceStatus == constants.ComplianceStatus.OK:
                 ok.append(r)
-            elif r.complianceStatus == ComplianceStatus.POTENTIALLY_DISALLOWED:
+            elif (
+                r.complianceStatus == constants.ComplianceStatus.POTENTIALLY_DISALLOWED
+            ):
                 potential.append(r)
-            elif r.complianceStatus == ComplianceStatus.DISALLOWED:
+            elif r.complianceStatus == constants.ComplianceStatus.DISALLOWED:
                 disallowed.append(r)
-        
-        disallowed.sort(key=lambda x: (
-            x.complianceFailureReason if x.complianceFailureReason is not None else 999
-        ))
-        
-        ok.sort(key=lambda x: (
-            ResponseFormatter._get_status_priority(x), 
-            x.artist.lower() if x.artist else ''
-        ))
-        potential.sort(key=lambda x: x.artist.lower() if x.artist else '')
-        
-        return CategorizedResponses(ok=ok, potential=potential, disallowed=disallowed, 
-                                   failed_ids=failed_ids or [])
-    
+
+        disallowed.sort(
+            key=lambda x: (
+                x.complianceFailureReason
+                if x.complianceFailureReason is not None
+                else 999
+            )
+        )
+
+        if is_raw:
+            ok.sort(key=lambda x: x.artist.lower() if x.artist else "")
+        else:
+            ok.sort(
+                key=lambda x: (
+                    ResponseFormatter._get_status_priority(x),
+                    x.artist.lower() if x.artist else "",
+                )
+            )
+        potential.sort(key=lambda x: x.artist.lower() if x.artist else "")
+
+        return CategorizedResponses(
+            ok=ok,
+            potential=potential,
+            disallowed=disallowed,
+            failed_ids=failed_ids or [],
+            is_raw=is_raw,
+        )
+
     @staticmethod
     def _get_status_priority(response: api.ValidationResponse) -> int:
         if response.status in ["ranked", "approved"]:
@@ -153,231 +217,364 @@ class InputSanitizer:
     def sanitize_map_ids(user_input: str) -> set[int]:
         if not user_input:
             return set()
-        
-        cleaned = (user_input
-                  .replace(',', ' ')
-                  .replace('\t', ' ')
-                  .replace('\n', ' ')
-                  .replace('#osu', '')
-                  .replace('#taiko', '')
-                  .replace('#fruits', '')
-                  .replace('#mania', ''))
-        
+
+        cleaned = (
+            user_input.replace(",", " ")
+            .replace("\t", " ")
+            .replace("\n", " ")
+            .replace("#osu", "")
+            .replace("#taiko", "")
+            .replace("#fruits", "")
+            .replace("#mania", "")
+        )
+
         ids = set()
         for part in cleaned.split():
             try:
-                if '/' in part:
-                    part = part.split('/')[-1]
+                if "/" in part:
+                    part = part.split("/")[-1]
                 map_id = int(part)
                 if map_id > 0:
                     ids.add(map_id)
             except (ValueError, TypeError):
                 continue
-        
+
         return ids
 
 
 class MenuBuilder:
     @staticmethod
-    def create_embeds(responses: list[api.ValidationResponse], 
-                     failed_ids: list[int],
-                     title: str, 
-                     color: discord.Color) -> list[Embed]:
+    def create_embeds(
+        responses: Sequence[AnyValidationResponse],
+        failed_ids: list[int],
+        title: str,
+        color: discord.Color,
+    ) -> list[Embed]:
         if not responses and not failed_ids:
-            embed = discord.Embed(title=title, description="No beatmaps found", color=color)
+            embed = discord.Embed(
+                title=title, description="No beatmaps found", color=color
+            )
             return [embed]
-        
+
         embeds = []
         line_items = [ResponseFormatter.format_line_item(r) for r in responses]
-        
+
         # Add failed beatmap IDs with error emoji and note
         for beatmap_id in failed_ids:
             line_items.append(f"⁉️ Beatmap ID {beatmap_id} - Processing failed")
-        
-        for i in range(0, len(line_items), PAGE_SIZE):
+
+        for i in range(0, len(line_items), constants.PAGE_SIZE):
             embed = discord.Embed(title=title, color=color)
-            embed.description = '\n'.join(line_items[i:i + PAGE_SIZE])
+            embed.description = "\n".join(line_items[i : i + constants.PAGE_SIZE])
             embeds.append(embed)
-        
+
         return embeds
-    
+
     @staticmethod
-    def get_status_color(categorized: CategorizedResponses) -> tuple[str, discord.Color]:
+    def get_status_color(
+        categorized: CategorizedResponses,
+    ) -> tuple[str, discord.Color]:
         if categorized.dmca_count > 0 or categorized.other_disallowed_count > 0:
-            return FAILURE_TEXT, discord.Color.red()
+            return constants.FAILURE_TEXT, discord.Color.red()
         elif categorized.potential_count > 0 or categorized.failed_count > 0:
-            return WARN_TEXT, discord.Color.yellow()
+            return constants.WARN_TEXT, discord.Color.yellow()
         else:
-            return SUCCESS_TEXT, discord.Color.green()
-    
+            return constants.SUCCESS_TEXT, discord.Color.green()
+
     @staticmethod
     def build_footer_text(categorized: CategorizedResponses, status_text: str) -> str:
-        footer = (f'\n{status_text}\n️'
-                 f'⛔: {categorized.dmca_count} | '
-                 f'❌: {categorized.other_disallowed_count} | '
-                 f'⚠️: {categorized.potential_count} | '
-                 f'☑️: {categorized.graveyard_count} | '
-                 f'✅ / 💞: {categorized.ranked_count}')
-        
-        if categorized.failed_count > 0:
-            footer += f' | ⁉️: {categorized.failed_count}'
-        
-        return footer
-    
-    @staticmethod
-    def create_menu(interaction: discord.Interaction, 
-                   responses: list[api.ValidationResponse],
-                   failed_ids: Optional[list[int]] = None) -> Optional[ViewMenu]:
-        try:
-            logger.debug(f"Creating menu for {len(responses)} responses and {len(failed_ids or [])} failures")
-            
-            categorized = ResponseFormatter.categorize_responses(responses, failed_ids)
-            combined = categorized.get_combined_list()
-            
-            logger.debug(f"Combined list has {len(combined)} items")
-            
-            status_text, color = MenuBuilder.get_status_color(categorized)
-            
-            embeds = MenuBuilder.create_embeds(
-                combined,
-                categorized.failed_ids,
-                "Validation Result", 
-                color
+        if categorized.is_raw:
+            footer = (
+                f"\n{status_text}\n️"
+                f"⛔: {categorized.dmca_count} | "
+                f"❌: {categorized.other_disallowed_count} | "
+                f"⚠️: {categorized.potential_count} | "
+                f"☑️: {categorized.ok_count}"
             )
-            
+        else:
+            footer = (
+                f"\n{status_text}\n️"
+                f"⛔: {categorized.dmca_count} | "
+                f"❌: {categorized.other_disallowed_count} | "
+                f"⚠️: {categorized.potential_count} | "
+                f"☑️: {categorized.graveyard_count} | "
+                f"✅ / 💞: {categorized.ranked_count}"
+            )
+
+        if categorized.failed_count > 0:
+            footer += f" | ⁉️: {categorized.failed_count}"
+
+        return footer
+
+    @staticmethod
+    def create_menu(
+        interaction: discord.Interaction,
+        responses: Sequence[AnyValidationResponse],
+        failed_ids: Optional[list[int]] = None,
+        is_raw: bool = False,
+    ) -> Optional[ViewMenu]:
+        try:
+            logger.debug(
+                f"Creating menu for {len(responses)} responses and {len(failed_ids or [])} failures"
+            )
+
+            categorized = ResponseFormatter.categorize_responses(
+                responses, failed_ids, is_raw=is_raw
+            )
+            combined = categorized.get_combined_list()
+
+            logger.debug(f"Combined list has {len(combined)} items")
+
+            status_text, color = MenuBuilder.get_status_color(categorized)
+
+            embeds = MenuBuilder.create_embeds(
+                combined, categorized.failed_ids, "Validation Result", color
+            )
+
             logger.debug(f"Created {len(embeds)} embed(s)")
-            
+
             footer_text = MenuBuilder.build_footer_text(categorized, status_text)
             for embed in embeds:
                 embed.set_footer(text=footer_text)
-            
+
             view_menu = ViewMenu(interaction, menu_type=ViewMenu.TypeEmbed)
             view_menu.add_pages(embeds)
-            
+
             logger.debug(f"ViewMenu created with {len(embeds)} pages")
-            
+
             back_button = ViewButton.back()
             next_button = ViewButton.next()
-            
+
             if len(embeds) <= 1:
                 back_button.disabled = True
                 next_button.disabled = True
-            
+
             view_menu.add_button(back_button)
             view_menu.add_button(next_button)
-            
+
             return view_menu
-            
+
         except Exception as e:
             logger.error(f"Error creating menu: {e}", exc_info=True)
             return None
 
 
 def setup_logging() -> None:
-    if not os.path.exists(LOG_DIR):
-        os.mkdir(LOG_DIR)
-    
-    log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+    if not os.path.exists(constants.LOG_DIR):
+        os.mkdir(constants.LOG_DIR)
+
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     numeric_level = getattr(logging, log_level, logging.INFO)
-    
+
     root_logger = logging.getLogger()
     root_logger.setLevel(numeric_level)
-    
+
     file_handler = logging.handlers.RotatingFileHandler(
-        filename=LOG_FILE,
-        encoding='utf-8',
-        maxBytes=LOG_MAX_BYTES,
-        backupCount=LOG_BACKUP_COUNT
+        filename=constants.LOG_FILE,
+        encoding="utf-8",
+        maxBytes=constants.LOG_MAX_BYTES,
+        backupCount=constants.LOG_BACKUP_COUNT,
     )
-    
-    formatter = logging.Formatter(LOG_FORMAT, LOG_DATE_FORMAT, style='{')
+
+    formatter = logging.Formatter(
+        constants.LOG_FORMAT, constants.LOG_DATE_FORMAT, style="{"
+    )
     file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)
-    
+
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)
-    
+
     logger.info(f"Logging configured at {log_level} level")
 
 
 @client.event
 async def on_ready():
-    logger.info(f'Logged in as {client.user}')
+    logger.info(f"Logged in as {client.user}")
     await tree.sync()
-    logger.info('Commands synced, bot is ready!')
+    logger.info("Commands synced, bot is ready!")
 
 
-@tree.command(description="Validates a list of maps against osu!'s content-usage listing.")
-@app_commands.checks.cooldown(COOLDOWN_RATE, COOLDOWN_PER)
-async def validate(ctx: discord.Interaction, u_input: str):
+@tree.command(
+    description="Validates a list of maps against osu!'s content-usage listing."
+)
+@app_commands.describe(strict="Enable strict validation mode")
+@app_commands.checks.cooldown(constants.COOLDOWN_RATE, constants.COOLDOWN_PER)
+async def validate(ctx: discord.Interaction, u_input: str, strict: bool = False):
     """Validates a mappool. Input should be a list of map IDs separated by commas, spaces, tabs, or new lines."""
     await ctx.response.defer()
-    
+
     map_ids = InputSanitizer.sanitize_map_ids(u_input)
-    
+
     if not map_ids:
-        await ctx.followup.send('Invalid input: No valid map IDs found.')
+        await ctx.followup.send("Invalid input: No valid map IDs found.")
         return
-    
+
     try:
-        api_response = await api.validate(list(map_ids))
-        
+        api_response = await api.validate(list(map_ids), strict=strict)
+
         if api_response is None:
-            await ctx.followup.send('Failed to validate beatmaps. Please try again later.')
+            await ctx.followup.send(
+                "Failed to validate beatmaps. Please try again later."
+            )
             return
-        
+
         if not api_response.results and not api_response.failures:
-            await ctx.followup.send('No beatmap data received from the API.')
+            await ctx.followup.send("No beatmap data received from the API.")
             return
-        
+
         logger.info(f"Validating {len(map_ids)} beatmaps for {ctx.user}")
         if api_response.failures:
-            logger.warning(f"Failed to process {len(api_response.failures)} beatmaps: {api_response.failures}")
-        
-        view_menu = MenuBuilder.create_menu(ctx, api_response.results, api_response.failures)
+            logger.warning(
+                f"Failed to process {len(api_response.failures)} beatmaps: {api_response.failures}"
+            )
+
+        view_menu = MenuBuilder.create_menu(
+            ctx, api_response.results, api_response.failures
+        )
         if view_menu is None:
-            await ctx.followup.send('An error occurred while creating the response menu.')
+            await ctx.followup.send(
+                "An error occurred while creating the response menu."
+            )
             return
-            
+
         logger.debug("Starting ViewMenu")
         await view_menu.start()
         logger.debug("ViewMenu started successfully")
-        
+
     except ValueError as e:
-        logger.warning(f'Invalid input: {e}')
-        await ctx.followup.send(f'Invalid input: {e}')
+        logger.warning(f"Invalid input: {e}")
+        await ctx.followup.send(f"Invalid input: {e}")
     except Exception as e:
-        logger.error(f'Unexpected error during validation: {e}', exc_info=True)
-        await ctx.followup.send('An unexpected error occurred. Please try again later.')
+        logger.error(f"Unexpected error during validation: {e}", exc_info=True)
+        await ctx.followup.send("An unexpected error occurred. Please try again later.")
+
+
+@tree.command(
+    description="Validates a CSV of artist/title metadata against osu!'s content-usage listing."
+)
+@app_commands.describe(
+    file="A CSV file with artist and title columns",
+    strict="Enable strict validation mode",
+)
+@app_commands.checks.cooldown(constants.COOLDOWN_RATE, constants.COOLDOWN_PER)
+async def validate_csv(
+    ctx: discord.Interaction, file: discord.Attachment, strict: bool = False
+):
+    await ctx.response.defer()
+
+    if not file.filename.lower().endswith(".csv"):
+        await ctx.followup.send("Invalid file type. Please upload a `.csv` file.")
+        return
+
+    try:
+        raw_bytes = await file.read()
+        try:
+            text = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            text = raw_bytes.decode("utf-8-sig")
+
+        reader = csv.DictReader(io.StringIO(text))
+        if reader.fieldnames is None:
+            await ctx.followup.send(
+                "CSV file appears to be empty or has no header row."
+            )
+            return
+
+        lower_fields = {f.lower().strip(): f for f in reader.fieldnames}
+        if "artist" not in lower_fields or "title" not in lower_fields:
+            await ctx.followup.send("CSV must contain `artist` and `title` columns.")
+            return
+
+        artist_col = lower_fields["artist"]
+        title_col = lower_fields["title"]
+        artist_unicode_col = lower_fields.get("artist_unicode")
+        title_unicode_col = lower_fields.get("title_unicode")
+
+        inputs = []
+        for row in reader:
+            artist = (row.get(artist_col) or "").strip()
+            title = (row.get(title_col) or "").strip()
+            if not artist or not title:
+                continue
+
+            artist_unicode = (
+                (row.get(artist_unicode_col) or "").strip()
+                if artist_unicode_col
+                else ""
+            )
+            title_unicode = (
+                (row.get(title_unicode_col) or "").strip() if title_unicode_col else ""
+            )
+
+            inputs.append(
+                {
+                    "artist": artist,
+                    "title": title,
+                    "artist_unicode": artist_unicode or artist,
+                    "title_unicode": title_unicode or title,
+                }
+            )
+
+        if not inputs:
+            await ctx.followup.send("No valid rows found in the CSV file.")
+            return
+
+        logger.info(f"Validating {len(inputs)} metadata entries for {ctx.user}")
+        results = await api.validate_metadata(inputs, strict=strict)
+
+        if results is None:
+            await ctx.followup.send(
+                "Failed to validate metadata. Please try again later."
+            )
+            return
+
+        if not results:
+            await ctx.followup.send("No results received from the API.")
+            return
+
+        view_menu = MenuBuilder.create_menu(ctx, results, is_raw=True)
+        if view_menu is None:
+            await ctx.followup.send(
+                "An error occurred while creating the response menu."
+            )
+            return
+
+        await view_menu.start()
+
+    except Exception as e:
+        logger.error(f"Unexpected error during CSV validation: {e}", exc_info=True)
+        await ctx.followup.send("An unexpected error occurred. Please try again later.")
 
 
 @tree.error
-async def on_app_command_error(interaction: discord.Interaction, error: app_commands.AppCommandError):
+async def on_app_command_error(
+    interaction: discord.Interaction, error: app_commands.AppCommandError
+):
     if isinstance(error, app_commands.CommandOnCooldown):
         await interaction.response.send_message(
-            f"Command is on cooldown. Try again in {error.retry_after:.2f} seconds.", 
-            ephemeral=True
+            f"Command is on cooldown. Try again in {error.retry_after:.2f} seconds.",
+            ephemeral=True,
         )
     else:
         logger.error(f"Unhandled command error: {error}", exc_info=True)
         if not interaction.response.is_done():
             await interaction.response.send_message(
-                "An error occurred while processing the command.",
-                ephemeral=True
+                "An error occurred while processing the command.", ephemeral=True
             )
 
 
 def run():
     setup_logging()
-    
-    token = os.getenv('TOKEN')
+
+    token = os.getenv("TOKEN")
     if not token:
-        logger.error('TOKEN environment variable not set')
+        logger.error("TOKEN environment variable not set")
         return
-    
+
     try:
         client.run(token, log_handler=None)
     except Exception as e:
-        logger.error(f'Failed to start bot: {e}', exc_info=True)
+        logger.error(f"Failed to start bot: {e}", exc_info=True)
         raise


### PR DESCRIPTION
This PR:

- Fixes improper API omc-api response handling (now handles `artist_unicode` and `title_unicode` in response body).
- Adds support for CSV data through `/validate-csv`